### PR TITLE
fix: Bump to Flask 2.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Flask==2.0.2
+Flask==2.3.3
 gunicorn==20.1.0


### PR DESCRIPTION
Flask 2.0.2 appears to be broken because one of its dependencies change and removed an exported function.